### PR TITLE
Use sprint instead of redirecting stdout

### DIFF
--- a/src/DocumentFunction.jl
+++ b/src/DocumentFunction.jl
@@ -56,7 +56,7 @@ function documentfunction(f::Function; location::Bool=true, maintext::String="",
 	modulename = first(methods(f)).module
 	stdoutcaptureon()
 	if maintext != ""
-		println("**$(f)**\n")
+		println("**", parentmodule(f), ".", nameof(f), "**\n")
 		println("$(maintext)\n")
 	end
 	ms = getfunctionmethods(f)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,14 +13,12 @@ output = DocumentFunction.documentfunction(DocumentFunction.documentfunction;
 				 "keytext"=>"Dictionary with text for each keyword",
 				 "location"=>"Boolean to show/hide function location on the disk"))
 
-DocumentFunction.documentfunction(DocumentFunction.stdoutcaptureon; location=true)
-DocumentFunction.getfunctionkeywords(DocumentFunction.stdoutcaptureon)
-DocumentFunction.getfunctionarguments(DocumentFunction.stdoutcaptureon)
-
+DocumentFunction.documentfunction(DocumentFunction.documentfunction; location=true)
+noargfunction() = nothing
 @Test.testset "Document" begin
     @Test.test output == expected
-    @Test.test [] == DocumentFunction.getfunctionkeywords(DocumentFunction.stdoutcaptureon)
-    @Test.test [] == DocumentFunction.getfunctionarguments(DocumentFunction.stdoutcaptureon)
+    @Test.test [] == DocumentFunction.getfunctionkeywords(DocumentFunction.getfunctionmethods)
+    @Test.test [] == DocumentFunction.getfunctionarguments(noargfunction)
 end
 
 :passed


### PR DESCRIPTION
Redirecting stdout just to get a string of what is printed is quite unreliable. Other things can write to stdout in the meantime and to be sure that one has read everything from stdout you probably need to write some terminating sentinel and use a `readuntil` waiting for that etc.

Anyway, just using `sprint` should be more idiomatic and more reliable.